### PR TITLE
Fix desync in TridentEntity DataTracker (and fix harpoon glint)

### DIFF
--- a/src/main/java/com/github/platymemo/alaskanativecraft/client/renderer/entity/HarpoonEntityRenderer.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/client/renderer/entity/HarpoonEntityRenderer.java
@@ -32,7 +32,7 @@ public class HarpoonEntityRenderer extends EntityRenderer<HarpoonEntity> {
         matrixStack.push();
         matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(MathHelper.lerp(g, harpoon.prevYaw, harpoon.yaw) - 90.0F));
         matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(MathHelper.lerp(g, harpoon.prevPitch, harpoon.pitch) + 90.0F));
-        VertexConsumer vertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, model.getLayer(this.getTexture(harpoon)), false, harpoon.isEnchanted());
+        VertexConsumer vertexConsumer = ItemRenderer.getDirectItemGlintConsumer(vertexConsumerProvider, model.getLayer(this.getTexture(harpoon)), false, harpoon.isEnchanted());
         model.render(matrixStack, vertexConsumer, i, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F, 1.0F, 1.0F);
         matrixStack.scale(2.0F, -2.0F, -2.0F);
         matrixStack.pop();

--- a/src/main/java/com/github/platymemo/alaskanativecraft/entity/HarpoonEntity.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/entity/HarpoonEntity.java
@@ -286,7 +286,7 @@ public class HarpoonEntity extends PersistentProjectileEntity {
     }
 
     static {
-        ENCHANTED = DataTracker.registerData(TridentEntity.class, TrackedDataHandlerRegistry.BOOLEAN);
+        ENCHANTED = DataTracker.registerData(HarpoonEntity.class, TrackedDataHandlerRegistry.BOOLEAN);
     }
 
     enum State {


### PR DESCRIPTION
## Issue

When this mod is run on a server and a client connects to it, throwing a trident will throw an `IllegalStateException` on the client side:

> [main/FATAL] [class_1255]: Error executing task on Client
java.lang.IllegalStateException: Invalid entity data item type for field 10 on entity class_1685['Trident'/93715, l='ClientLevel', x=-1238.14, y=200.52, z=296.48]: old=0(class java.lang.Byte), new=true(class java.lang.Boolean)
	at Not Enough Crashes deobfuscated stack trace.(1.16.5+build.6) ~[?:?]
	at net.minecraft.entity.data.DataTracker.copyToFrom(DataTracker:241) ~[?:?]
	at net.minecraft.entity.data.DataTracker.writeUpdatedEntries(DataTracker:228) ~[?:?]
	at net.minecraft.client.network.ClientPlayNetworkHandler.onEntityTrackerUpdate(ClientPlayNetworkHandler:568) ~[?:?]
	at net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket.apply(EntityTrackerUpdateS2CPacket:42) ~[?:?]
	at net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket.apply(EntityTrackerUpdateS2CPacket:11) ~[?:?]
	...

The reason for this is that `HarpoonEntity` adds a `DataTracker` entry for the `TridentEntity`.
The server will execute the `static` block this happens in while the client might not, thus it tries to write a `Boolean` where a `Byte` is expected ("old=0(class java.lang.Byte), new=true(class java.lang.Boolean)").

The fix is simply registering the data tracker entry for the `HarpoonEntity` instead.

While testing this, I also noticed that while `harpoon.isEnchanted()` is properly synchronized,
https://github.com/Platymemo/alaskanativecraft/blob/7d322c7e32a57d000c9b387798644577fda39a64/src/main/java/com/github/platymemo/alaskanativecraft/client/renderer/entity/HarpoonEntityRenderer.java#L35

doesn't actually apply any glint. Tridents use `getDirectItemGlintConsumer` here, so I fixed this as well.