### PR TITLE
Possible fix for stacking Problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ bin/
 # fabric
 
 run/
+libs/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	# check these on https://fabricmc.net/use
+	# check these on https://fabricmc.net/versions.html
 	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.32
+	yarn_mappings=1.17.1+build.35
 	loader_version=0.11.6
 
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.11.6
 
 # Mod Properties
-	mod_version = 1.3.0
+	mod_version = 1.3.1
 	maven_group = com.github.platymemo
 	archives_base_name = alaskanativecraft
 

--- a/src/main/java/com/github/platymemo/alaskanativecraft/entity/HarpoonEntity.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/entity/HarpoonEntity.java
@@ -1,6 +1,7 @@
 package com.github.platymemo.alaskanativecraft.entity;
 
 import com.github.platymemo.alaskanativecraft.AlaskaNativeCraft;
+import com.github.platymemo.alaskanativecraft.entity.HarpoonEntity.State;
 import com.github.platymemo.alaskanativecraft.item.HarpoonItem;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;

--- a/src/main/java/com/github/platymemo/alaskanativecraft/entity/MooseEntity.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/entity/MooseEntity.java
@@ -162,7 +162,7 @@ public class MooseEntity extends AnimalEntity {
                     MooseEntity.this.getBlockZ() + 3
             );
 
-            for (var blockPos : iterable) {
+            for (BlockPos blockPos : iterable) {
                 if (MooseEntity.this.world.getBlockState(blockPos).isIn(CommonBlockTags.LOGS_WITH_BARK)) {
                     return Vec3d.ofBottomCenter(blockPos);
                 }

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/GrindstoneScreenHandlerMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/GrindstoneScreenHandlerMixin.java
@@ -3,6 +3,7 @@ package com.github.platymemo.alaskanativecraft.mixin;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.screen.GrindstoneScreenHandler;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Final;
@@ -26,7 +27,8 @@ public abstract class GrindstoneScreenHandlerMixin {
 
     @Inject(method = "transferEnchantments", at = @At("RETURN"))
     private void copyDurabilityMultiplier(ItemStack target, @NotNull ItemStack source, CallbackInfoReturnable<ItemStack> cir) {
-        if (source.getOrCreateNbt().contains("DurabilityMultiplier")) {
+        final NbtCompound tag = source.getNbt();
+        if (tag!=null && tag.contains("DurabilityMultiplier")) {
             cir.getReturnValue().getOrCreateNbt().putFloat("DurabilityMultiplier", source.getOrCreateNbt().getFloat("DurabilityMultiplier"));
         }
     }

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/ItemMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/ItemMixin.java
@@ -2,6 +2,7 @@ package com.github.platymemo.alaskanativecraft.mixin;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -17,8 +18,9 @@ public abstract class ItemMixin {
     @Redirect(method = {"getItemBarStep", "getItemBarColor"}, at = @At(value = "FIELD", target = "Lnet/minecraft/item/Item;maxDamage:I"))
     private int redirectForDurabilityMultiplier(Item item, ItemStack stack) {
         int newMaxDamage = this.maxDamage;
-        if (this.isDamageable() && stack.getOrCreateNbt().contains("DurabilityMultiplier")) {
-            newMaxDamage *= stack.getOrCreateNbt().getFloat("DurabilityMultiplier");
+        final NbtCompound tag = stack.getNbt();
+        if (this.isDamageable() && tag!=null && tag.contains("DurabilityMultiplier")) {
+            newMaxDamage *= tag.getFloat("DurabilityMultiplier");
         }
         return newMaxDamage;
     }

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/ItemStackMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/ItemStackMixin.java
@@ -20,7 +20,8 @@ public abstract class ItemStackMixin {
 
     @Inject(method = "getMaxDamage", at = @At("RETURN"), cancellable = true)
     private void durabilityMultiplier(CallbackInfoReturnable<Integer> cir) {
-        if (this.getOrCreateNbt().contains("DurabilityMultiplier")) {
+        final NbtCompound tag = getNbt();
+        if (tag!=null && tag.contains("DurabilityMultiplier")) {
             int newDurability = cir.getReturnValue();
             newDurability *= this.getOrCreateNbt().getFloat("DurabilityMultiplier");
             cir.setReturnValue(newDurability);

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/RepairItemRecipeMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/RepairItemRecipeMixin.java
@@ -3,6 +3,7 @@ package com.github.platymemo.alaskanativecraft.mixin;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.recipe.RepairItemRecipe;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
@@ -33,8 +34,9 @@ public abstract class RepairItemRecipeMixin {
 
     @Inject(method = "craft", at = @At("RETURN"))
     private void addDurabilityMultiplier(CraftingInventory craftingInventory, @NotNull CallbackInfoReturnable<ItemStack> cir) {
-        if (!cir.getReturnValue().isEmpty() && anc$cachedStack.getOrCreateNbt().contains("DurabilityMultiplier")) {
-            cir.getReturnValue().getOrCreateNbt().putFloat("DurabilityMultiplier", anc$cachedStack.getOrCreateNbt().getFloat("DurabilityMultiplier"));
+        final NbtCompound tag = anc$cachedStack.getNbt();
+        if (!cir.getReturnValue().isEmpty() && tag!=null && tag.contains("DurabilityMultiplier")) {
+            cir.getReturnValue().getOrCreateNbt().putFloat("DurabilityMultiplier", tag.getFloat("DurabilityMultiplier"));
         }
     }
 }


### PR DESCRIPTION
Replace `getOrCreateTag` with `getTag` and null-test when checking for `DurabilityMultiplier`. This shouldprevent the generation of empty `tag`-entries that prevent stacking.

#41 is fixed in my test. The code for the `DurabilityMultiplier` is executed (tested with diamond harpoon), but since I am not familiar with this new mechanic, I could have introduced a regression. 