### PR TITLE
Snow Overhaul

### DIFF
--- a/src/main/java/com/github/platymemo/alaskanativecraft/config/AlaskaConfig.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/config/AlaskaConfig.java
@@ -22,6 +22,10 @@ public class AlaskaConfig implements ConfigData {
 	public boolean mooseEatBark = true;
 	@ConfigEntry.Gui.CollapsibleObject
 	public SealFishing sealFishing = new SealFishing();
+	@ConfigEntry.Gui.RequiresRestart
+	public boolean snowOverhaul = true;
+	@ConfigEntry.Gui.RequiresRestart
+	public float snowSlow = 0.1f;
 
 	public static synchronized AlaskaConfig getConfig() {
 		if (!registered) {

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/LivingEntityMixin.java
@@ -3,6 +3,7 @@ package com.github.platymemo.alaskanativecraft.mixin;
 import java.util.Map;
 import java.util.UUID;
 
+import com.github.platymemo.alaskanativecraft.config.AlaskaConfig;
 import com.github.platymemo.alaskanativecraft.entity.effect.AlaskaEffects;
 import com.github.platymemo.alaskanativecraft.item.AlaskaItems;
 import com.github.platymemo.alaskanativecraft.tags.AlaskaTags;
@@ -13,6 +14,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.entity.Entity;
@@ -33,14 +35,15 @@ import net.minecraft.world.World;
 @Mixin(LivingEntity.class)
 public abstract class LivingEntityMixin extends Entity {
 	@Unique
-	private static final UUID SNOWSHOE_SPEED_BOOST_ID = UUID.fromString("0b824742-8bbc-4043-8caf-f997a543495f");
+	private static final UUID anc$SNOWSHOE_SPEED_BOOST_ID = UUID.fromString("0b824742-8bbc-4043-8caf-f997a543495f");
+	@Unique
+	private static final float anc$SNOWSHOE_SPEED_BOOST = 0.02f;
 	@Shadow
 	@Final
 	private Map<StatusEffect, StatusEffectInstance> activeStatusEffects;
 
 	protected LivingEntityMixin(EntityType<?> type, World world) {
 		super(type, world);
-		throw new AssertionError("wut");
 	}
 
 	@Shadow
@@ -53,22 +56,22 @@ public abstract class LivingEntityMixin extends Entity {
 	public abstract RandomGenerator getRandom();
 
 	@Inject(method = "removeSoulSpeedBoost", at = @At("TAIL"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-	protected void removeSnowshoeSpeedBoost(CallbackInfo ci, EntityAttributeInstance entityAttributeInstance) {
-		if (entityAttributeInstance != null && entityAttributeInstance.getModifier(SNOWSHOE_SPEED_BOOST_ID) != null) {
-			entityAttributeInstance.removeModifier(SNOWSHOE_SPEED_BOOST_ID);
+	protected void anc$removeSnowshoeSpeedBoost(CallbackInfo ci, EntityAttributeInstance entityAttributeInstance) {
+		if (entityAttributeInstance != null && entityAttributeInstance.getModifier(anc$SNOWSHOE_SPEED_BOOST_ID) != null) {
+			entityAttributeInstance.removeModifier(anc$SNOWSHOE_SPEED_BOOST_ID);
 		}
 	}
 
 	@Inject(method = "addSoulSpeedBoostIfNeeded", at = @At("TAIL"))
-	protected void addSnowshoeSpeedBoostIfNeeded(CallbackInfo ci) {
-		if (!this.getLandingBlockState().isAir()) {
-			if (this.getEquippedStack(EquipmentSlot.FEET).isOf(AlaskaItems.SNOWSHOES) && this.isOnSnowshoeSpeedBlock()) {
+	protected void anc$addSnowshoeSpeedBoostIfNeeded(CallbackInfo ci) {
+		if (!this.getLandingBlockStateLegacy().isAir()) {
+			if (this.getEquippedStack(EquipmentSlot.FEET).isOf(AlaskaItems.SNOWSHOES) && this.anc$isOnSnowshoeSpeedBlock()) {
 				EntityAttributeInstance entityAttributeInstance = this.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED);
 				if (entityAttributeInstance == null) {
 					return;
 				}
 
-				entityAttributeInstance.addTemporaryModifier(new EntityAttributeModifier(SNOWSHOE_SPEED_BOOST_ID, "Snowshoe speed boost", 0.025F, EntityAttributeModifier.Operation.ADDITION));
+				entityAttributeInstance.addTemporaryModifier(new EntityAttributeModifier(anc$SNOWSHOE_SPEED_BOOST_ID, "Snowshoe speed boost", anc$SNOWSHOE_SPEED_BOOST, EntityAttributeModifier.Operation.ADDITION));
 				if (this.getRandom().nextFloat() < 0.01F) {
 					ItemStack itemStack = this.getEquippedStack(EquipmentSlot.FEET);
 					itemStack.damage(1, (LivingEntity) (Object) this, player -> player.sendEquipmentBreakStatus(EquipmentSlot.FEET));
@@ -78,16 +81,27 @@ public abstract class LivingEntityMixin extends Entity {
 	}
 
 	@Unique
-	protected boolean isOnSnowshoeSpeedBlock() {
+	protected boolean anc$isOnSnowshoeSpeedBlock() {
 		BlockPos pos = this.getVelocityAffectingPos();
-		return this.world.getBlockState(pos).isIn(AlaskaTags.SNOWSHOE_SPEED_BLOCKS) || this.world.getBlockState(pos.up()).isIn(AlaskaTags.SNOWSHOE_SPEED_BLOCKS);
+		return this.world.getBlockState(pos).isIn(AlaskaTags.SNOWSHOE_SPEED_BLOCKS)
+				|| this.world.getBlockState(pos.up()).isIn(AlaskaTags.SNOWSHOE_SPEED_BLOCKS);
+	}
+
+	@Inject(method = "getVelocityMultiplier", at = @At("HEAD"), cancellable = true)
+	private void anc$getVelocityWithSnowBoost(CallbackInfoReturnable<Float> cir) {
+		if (this.anc$isOnSnowshoeSpeedBlock()
+				&& (this.getEquippedStack(EquipmentSlot.FEET).isOf(AlaskaItems.SNOWSHOES)
+					|| (AlaskaConfig.getConfig().snowOverhaul
+						&& this.getEquippedStack(EquipmentSlot.FEET).isOf(AlaskaItems.MUKLUKS)))) {
+			cir.setReturnValue(1.0f);
+		}
 	}
 
 	/*
 	 * We have to tick the medicinal effect before all the others because we modify the list of active effects
 	 */
 	@Inject(method = "tickStatusEffects", at = @At("HEAD"))
-	private void tickMedicinalEffect(CallbackInfo ci) {
+	private void anc$tickMedicinalEffect(CallbackInfo ci) {
 		if (this.activeStatusEffects.containsKey(AlaskaEffects.MEDICINAL)) {
 			var statusEffect = this.activeStatusEffects.get(AlaskaEffects.MEDICINAL);
 			var duration = statusEffect.getDuration();

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/PowderSnowBlockMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/PowderSnowBlockMixin.java
@@ -1,27 +1,34 @@
 package com.github.platymemo.alaskanativecraft.mixin;
 
+import com.github.platymemo.alaskanativecraft.config.AlaskaConfig;
 import com.github.platymemo.alaskanativecraft.item.AlaskaItems;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.block.PowderSnowBlock;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Vec3d;
 
 @Mixin(PowderSnowBlock.class)
 public class PowderSnowBlockMixin {
-	@Inject(method = "canWalkOnPowderSnow", at = @At(value = "RETURN", ordinal = 1), cancellable = true)
-	private static void isWearingSnowshoesOrMukluks(Entity entity, CallbackInfoReturnable<Boolean> cir) {
-		if (entity instanceof LivingEntity livingEntity) {
-			var stack = livingEntity.getEquippedStack(EquipmentSlot.FEET);
-			cir.setReturnValue(stack.isOf(AlaskaItems.SNOWSHOES) || stack.isOf(AlaskaItems.MUKLUKS));
+	// Also prevents leather boots from letting an entity walk on snow
+	@Redirect(method = "canWalkOnPowderSnow", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;isOf(Lnet/minecraft/item/Item;)Z"))
+	private static boolean anc$isWearingSnowshoes(ItemStack stack, Item item) {
+		return stack.isOf(AlaskaItems.SNOWSHOES);
+	}
+
+	@Redirect(method = "onEntityCollision", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;slowMovement(Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/Vec3d;)V"))
+	private void anc$dontSlowWithMukluks(Entity entity, BlockState state, Vec3d vec3d) {
+		if (!(entity instanceof LivingEntity) || (AlaskaConfig.getConfig().snowOverhaul && ((LivingEntity) entity).getEquippedStack(EquipmentSlot.FEET).isOf(AlaskaItems.MUKLUKS))) {
 			return;
 		}
 
-		// Prevents leather boots from allowing snow walking
-		cir.setReturnValue(false);
+		entity.slowMovement(state, vec3d);
 	}
 }

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/AbstractBlockMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/AbstractBlockMixin.java
@@ -1,0 +1,99 @@
+package com.github.platymemo.alaskanativecraft.mixin.snow;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.EntityShapeContext;
+import net.minecraft.block.PowderSnowBlock;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.block.SnowBlock;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.FallingBlockEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.particle.ParticleTypes;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.random.RandomGenerator;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.World;
+
+@Mixin(AbstractBlock.class)
+public class AbstractBlockMixin {
+	// A half-block in height
+	@Unique
+	private static final VoxelShape anc$SNOW_BLOCK_SHAPE = Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 8.0, 16.0);
+
+	@Inject(method = "getCollisionShape", at = @At("HEAD"), cancellable = true)
+	private void anc$snowCollisionShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context, CallbackInfoReturnable<VoxelShape> cir) {
+		if (state.isOf(Blocks.SNOW_BLOCK)) {
+			// Act like a full cube for falling blocks and entities that can walk on powder snow
+			if (context instanceof EntityShapeContext entityShapeContext) {
+				Entity entity = entityShapeContext.getEntity();
+				if (entity instanceof FallingBlockEntity
+						|| (entityShapeContext == ShapeContext.absent())
+						|| (entity != null && PowderSnowBlock.canWalkOnPowderSnow(entity) && context.isAbove(VoxelShapes.fullCube(), pos, false) && !context.isDescending())) {
+					cir.setReturnValue(VoxelShapes.fullCube());
+					return;
+				}
+			}
+
+			// Smoothly modify collision shape for snow layers on top of snow blocks
+			var aboveState = world.getBlockState(pos.up());
+			if (aboveState.isOf(Blocks.SNOW)) {
+				cir.setReturnValue(SnowBlockAccessor.getLayers()[Math.min(SnowBlock.MAX_LAYERS, 4 + aboveState.get(SnowBlock.LAYERS))]);
+				return;
+			}
+
+			cir.setReturnValue(anc$SNOW_BLOCK_SHAPE);
+		}
+	}
+
+	@Inject(method = "onEntityCollision", at = @At("HEAD"))
+	protected void anc$onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity, CallbackInfo ci) {
+		if (state.isOf(Blocks.SNOW_BLOCK)) {
+			this.anc$snowEffects(state, world, pos, entity, 1);
+		}
+	}
+
+	@Unique
+	@SuppressWarnings("ConstantConditions")
+	protected void anc$snowEffects(BlockState state, World world, BlockPos pos, Entity entity, double particleHeight) {
+		if (!(entity instanceof LivingEntity) || entity.getBlockStateAtPos().getBlock() == (Object) this) {
+			if (world.isClient) {
+				RandomGenerator randomGenerator = world.getRandom();
+				boolean movedHorizontally = entity.lastRenderX != entity.getX() || entity.lastRenderZ != entity.getZ();
+				if (movedHorizontally && randomGenerator.nextBoolean()) {
+					world.addParticle(
+							ParticleTypes.SNOWFLAKE,
+							entity.getX(),
+							pos.getY() + particleHeight,
+							entity.getZ(),
+							MathHelper.nextBetween(randomGenerator, -1.0F, 1.0F) * 0.083333336F,
+							0.05F,
+							MathHelper.nextBetween(randomGenerator, -1.0F, 1.0F) * 0.083333336F
+					);
+				}
+			}
+		}
+
+		if (!world.isClient) {
+			if (entity.isOnFire() && (world.getGameRules().getBoolean(GameRules.DO_MOB_GRIEFING) || entity instanceof PlayerEntity) && entity.canModifyAt(world, pos)) {
+				world.breakBlock(pos, false);
+			}
+
+			entity.setOnFire(false);
+		}
+	}
+}

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/BlocksMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/BlocksMixin.java
@@ -1,0 +1,31 @@
+package com.github.platymemo.alaskanativecraft.mixin.snow;
+
+import com.github.platymemo.alaskanativecraft.config.AlaskaConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Blocks;
+
+/**
+ * Makes {@link Blocks#SNOW} and {@link Blocks#SNOW_BLOCK} slow entities down.
+ */
+@Mixin(Blocks.class)
+public class BlocksMixin {
+	@Unique
+	private static final float anc$SNOW_SLOW = 1.0f - AlaskaConfig.getConfig().snowSlow;
+
+	@ModifyArg(method = "<clinit>", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/SnowBlock;<init>(Lnet/minecraft/block/AbstractBlock$Settings;)V"))
+	private static AbstractBlock.Settings anc$addSlowToSnowSettings(AbstractBlock.Settings oldSettings) {
+		return oldSettings.velocityMultiplier(anc$SNOW_SLOW);
+	}
+
+	// TODO very brittle selection, can easily break
+	// We may want to use a slice
+	@ModifyArg(method = "<clinit>", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;<init>(Lnet/minecraft/block/AbstractBlock$Settings;)V", ordinal = 45))
+	private static AbstractBlock.Settings anc$addSlowToSnowBlockSettings(AbstractBlock.Settings oldSettings) {
+		return oldSettings.velocityMultiplier(anc$SNOW_SLOW);
+	}
+}

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/EntityMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/EntityMixin.java
@@ -1,0 +1,51 @@
+package com.github.platymemo.alaskanativecraft.mixin.snow;
+
+import com.github.platymemo.alaskanativecraft.config.AlaskaConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.SnowBlock;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin {
+	@Unique
+	private static final float anc$SNOW_SLOW = 1.0f - AlaskaConfig.getConfig().snowSlow;
+
+	@Shadow
+	public World world;
+
+	@Shadow
+	public abstract BlockPos getBlockPos();
+
+	@Shadow
+	protected abstract BlockPos getVelocityAffectingPos();
+
+	@ModifyVariable(method = "getVelocityMultiplier", at = @At(value = "STORE", ordinal = 0))
+	private float anc$ignoreSmallSnowLayers(float oldFloat) {
+		BlockState blockState = this.world.getBlockState(this.getBlockPos());
+		if (blockState.isOf(Blocks.SNOW) && blockState.get(SnowBlock.LAYERS) < 5) {
+			return MathHelper.lerp((blockState.get(SnowBlock.LAYERS) - 1.0f) / 3.0f, 1.0f, anc$SNOW_SLOW);
+		}
+
+		return oldFloat;
+	}
+
+	@Inject(method = "getVelocityMultiplier", at = @At(value = "RETURN", ordinal = 1), cancellable = true)
+	private void anc$ignoreSmallSnowLayers2ElectricBoogaloo(CallbackInfoReturnable<Float> cir) {
+		BlockState blockState = this.world.getBlockState(this.getVelocityAffectingPos());
+		if (blockState.isOf(Blocks.SNOW) && blockState.get(SnowBlock.LAYERS) < 5) {
+			cir.setReturnValue(MathHelper.lerp((blockState.get(SnowBlock.LAYERS) - 1.0f) / 3.0f, 1.0f, anc$SNOW_SLOW));
+		}
+	}
+}

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/SnowBlockAccessor.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/SnowBlockAccessor.java
@@ -1,0 +1,17 @@
+package com.github.platymemo.alaskanativecraft.mixin.snow;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.block.SnowBlock;
+import net.minecraft.util.shape.VoxelShape;
+
+@Mixin(SnowBlock.class)
+public interface SnowBlockAccessor {
+	@Accessor("LAYERS_TO_SHAPE")
+	@Final
+	static VoxelShape[] getLayers() {
+		throw new AssertionError("Mixin injection failed!");
+	}
+}

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/SnowBlockMixin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/SnowBlockMixin.java
@@ -1,0 +1,67 @@
+package com.github.platymemo.alaskanativecraft.mixin.snow;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.EntityShapeContext;
+import net.minecraft.block.PowderSnowBlock;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.block.SnowBlock;
+import net.minecraft.entity.Entity;
+import net.minecraft.state.property.IntProperty;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+
+@Mixin(SnowBlock.class)
+public abstract class SnowBlockMixin extends AbstractBlockMixin {
+	@Shadow
+	@Final
+	protected static VoxelShape[] LAYERS_TO_SHAPE;
+
+	@Shadow
+	@Final
+	public static IntProperty LAYERS;
+
+	@Shadow
+	@Final
+	public static int MAX_LAYERS;
+
+	@Inject(method = "getCollisionShape", at = @At("HEAD"), cancellable = true)
+	private void anc$fallThroughSnow(BlockState state, BlockView world, BlockPos pos, ShapeContext context, CallbackInfoReturnable<VoxelShape> cir) {
+		if (state.isOf(Blocks.SNOW)) {
+			if (context instanceof EntityShapeContext entityShapeContext) {
+				Entity entity = entityShapeContext.getEntity();
+				if (entityShapeContext == ShapeContext.absent()
+						|| (entity != null && PowderSnowBlock.canWalkOnPowderSnow(entity) && context.isAbove(LAYERS_TO_SHAPE[state.get(LAYERS)], pos, false) && !context.isDescending())) {
+					cir.setReturnValue(LAYERS_TO_SHAPE[state.get(LAYERS)]);
+					return;
+				}
+			}
+
+			// Smoothly modify collision shape for snow layers on top
+			var aboveState = world.getBlockState(pos.up());
+			if (aboveState.isOf(Blocks.SNOW)) {
+				cir.setReturnValue(LAYERS_TO_SHAPE[Math.min(MAX_LAYERS, 4 + aboveState.get(SnowBlock.LAYERS))]);
+				return;
+			}
+
+			cir.setReturnValue(LAYERS_TO_SHAPE[Math.max(0, state.get(LAYERS) - 4)]);
+		}
+	}
+
+	@Override
+	protected void anc$onEntityCollision(BlockState state, World world, BlockPos pos, Entity entity, CallbackInfo ci) {
+		if (state.isOf(Blocks.SNOW)) {
+			this.anc$snowEffects(state, world, pos, entity, ((float) state.get(LAYERS) / MAX_LAYERS));
+		}
+	}
+}

--- a/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/SnowMixinPlugin.java
+++ b/src/main/java/com/github/platymemo/alaskanativecraft/mixin/snow/SnowMixinPlugin.java
@@ -1,0 +1,38 @@
+package com.github.platymemo.alaskanativecraft.mixin.snow;
+
+import java.util.List;
+import java.util.Set;
+
+import com.github.platymemo.alaskanativecraft.config.AlaskaConfig;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+public class SnowMixinPlugin implements IMixinConfigPlugin {
+	@Override
+	public void onLoad(String mixinPackage) {}
+
+	@Override
+	public String getRefMapperConfig() {
+		return null;
+	}
+
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+		return AlaskaConfig.getConfig().snowOverhaul;
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+	@Override
+	public List<String> getMixins() {
+		return null;
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/src/main/resources/alaskanativecraft.snow.mixins.json
+++ b/src/main/resources/alaskanativecraft.snow.mixins.json
@@ -1,0 +1,17 @@
+{
+  "required": true,
+  "minVersion": "0.8.4",
+  "package": "com.github.platymemo.alaskanativecraft.mixin.snow",
+  "compatibilityLevel": "JAVA_17",
+  "plugin": "com.github.platymemo.alaskanativecraft.mixin.snow.SnowMixinPlugin",
+  "mixins": [
+    "AbstractBlockMixin",
+    "BlocksMixin",
+    "EntityMixin",
+    "SnowBlockAccessor",
+    "SnowBlockMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/resources/assets/alaskanativecraft/lang/en_us.json
+++ b/src/main/resources/assets/alaskanativecraft/lang/en_us.json
@@ -77,6 +77,8 @@
   "text.autoconfig.alaskanativecraft.title": "Alaska Native Craft",
   "text.autoconfig.alaskanativecraft.category.default": "General",
   "text.autoconfig.alaskanativecraft.option.snowballConversion": "Snowballs Convert Birds",
+  "text.autoconfig.alaskanativecraft.option.snowOverhaul": "Enable Snow Overhaul",
+  "text.autoconfig.alaskanativecraft.option.snowSlow": "How Much Snow Slows Entities",
   "text.autoconfig.alaskanativecraft.option.mooseEatBark": "Moose Strip Logs",
   "text.autoconfig.alaskanativecraft.option.sealFishing": "Seal Fish Hunting Mechanics",
   "text.autoconfig.alaskanativecraft.option.sealFishing.sealsHuntFish": "Seals Hunt Fish",

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -39,6 +39,9 @@
       }
     ]
   },
-  "mixin": "alaskanativecraft.mixins.json",
+  "mixin": [
+    "alaskanativecraft.mixins.json",
+    "alaskanativecraft.snow.mixins.json"
+  ],
   "access_widener": "alaskanativecraft.accesswidener"
 }


### PR DESCRIPTION
Overhaul the snow interactions in Minecraft.
1. Leather boots no longer allow entities to walk on powder snow
2. Snowshoes still allow entities to walk on snow
3. Entities now sink up to half a block into the snow
4. Snow applies a variable slow based on how deep an entity has sunk into it
5. Mukluks allow entities to ignore the slow of snow blocks